### PR TITLE
refactor: remove unused result action records in TodoListActions

### DIFF
--- a/kapa.fluxor.testing/kapa.fluxor.testing.Client/Store/TodoUseCase/TodoListActions.cs
+++ b/kapa.fluxor.testing/kapa.fluxor.testing.Client/Store/TodoUseCase/TodoListActions.cs
@@ -6,7 +6,5 @@ public record CreateTodoListItemAction(string Title, int Order);
 public record CreateTodoListItemResultAction(TodoListItem Item);
 
 public record UpdateTodoListItemAction(TodoListItem UpdatedItem);
-public record UpdateTodoListItemResultAction(List<TodoListItem> Items);
 
 public record DeleteTodoListItemAction(Guid Id);
-public record DeleteTodoListItemResultAction(List<TodoListItem> Items);


### PR DESCRIPTION
Eliminate `UpdateTodoListItemResultAction` and 
`DeleteTodoListItemResultAction` records as they are no longer 
needed. This simplifies the code and improves maintainability.